### PR TITLE
Improve clipper conversion operations performance

### DIFF
--- a/tests/Pmad.Geometry.Benchmark/PolygonSampleSet.cs
+++ b/tests/Pmad.Geometry.Benchmark/PolygonSampleSet.cs
@@ -1,0 +1,65 @@
+﻿using Clipper2Lib;
+using GameRealisticMap.Geometries;
+using NetTopologySuite.Geometries;
+using Pmad.Geometry.Collections;
+
+namespace Pmad.Geometry.Benchmark
+{
+    public class PolygonSampleSet
+    {
+        public static PolygonSampleSet CreateCircle(int radius)
+            => CreateCircle(0, 0, radius);
+
+        public static PolygonSampleSet CreateCircle(int x, int y, int radius) 
+            => new PolygonSampleSet(Enumerable.Range(0, 41).Select(a => new Vector2I((int)(Math.Cos(a * Math.PI / 20) * radius) + x, (int)(Math.Sin(a * Math.PI / 20) * radius) + y)));
+
+        public PolygonSampleSet(IEnumerable<Vector2I> source)
+        {
+            Points2I = source.ToReadOnlyArray();
+            Points2F = Points2I.Select(p => new Vector2F(p.X, p.Y)).ToReadOnlyArray();
+            Points2D = Points2I.Select(p => new Vector2D(p.X, p.Y)).ToReadOnlyArray();
+            Points2L = Points2I.Select(p => new Vector2L(p.X, p.Y)).ToReadOnlyArray();
+            Points2IS = Points2I.Select(p => new Vector2IS(p.X, p.Y)).ToReadOnlyArray();
+            Points2FS = Points2I.Select(p => new Vector2FS(p.X, p.Y)).ToReadOnlyArray();
+            Points2DS = Points2I.Select(p => new Vector2DS(p.X, p.Y)).ToReadOnlyArray();
+            Points2LS = Points2I.Select(p => new Vector2LS(p.X, p.Y)).ToReadOnlyArray();
+            PointsP64 = new Path64(Points2I.Select(p => new Point64(p.X, p.Y)));
+            PointsGRM = Points2I.Select(p => new TerrainPoint(p.X, p.Y)).ToList();
+            PointsNTS = Points2I.Select(p => new Coordinate(p.X, p.Y)).ToArray();
+
+            Polygon2I = new(Points2I);
+            Polygon2F = new(Points2F);
+            Polygon2D = new(Points2D);
+            Polygon2L = new(Points2L);
+            Polygon2IS = new(Points2IS);
+            Polygon2FS = new(Points2FS);
+            Polygon2DS = new(Points2DS);
+            Polygon2LS = new(Points2LS);
+            PolygonGRM = new(PointsGRM);
+            PolygonNTS = new(new(PointsNTS));
+        }
+
+        public readonly ReadOnlyArray<Vector2I> Points2I;
+        public readonly ReadOnlyArray<Vector2F> Points2F;
+        public readonly ReadOnlyArray<Vector2D> Points2D;
+        public readonly ReadOnlyArray<Vector2L> Points2L;
+        public readonly ReadOnlyArray<Vector2IS> Points2IS;
+        public readonly ReadOnlyArray<Vector2FS> Points2FS;
+        public readonly ReadOnlyArray<Vector2DS> Points2DS;
+        public readonly ReadOnlyArray<Vector2LS> Points2LS;
+        public readonly Path64 PointsP64;
+        public readonly List<TerrainPoint> PointsGRM;
+        public readonly Coordinate[] PointsNTS;
+
+        public readonly Shapes.Polygon<int, Vector2I> Polygon2I;
+        public readonly Shapes.Polygon<float, Vector2F> Polygon2F;
+        public readonly Shapes.Polygon<double, Vector2D> Polygon2D;
+        public readonly Shapes.Polygon<long, Vector2L> Polygon2L;
+        public readonly Shapes.Polygon<int, Vector2IS> Polygon2IS;
+        public readonly Shapes.Polygon<float, Vector2FS> Polygon2FS;
+        public readonly Shapes.Polygon<double, Vector2DS> Polygon2DS;
+        public readonly Shapes.Polygon<long, Vector2LS> Polygon2LS;
+        public readonly TerrainPolygon PolygonGRM;
+        public readonly Polygon PolygonNTS;
+    }
+}

--- a/tests/Pmad.Geometry.Benchmark/Program.cs
+++ b/tests/Pmad.Geometry.Benchmark/Program.cs
@@ -28,7 +28,7 @@ namespace Pmad.Geometry.Benchmark
                     //typeof(CrossProduct3Benchmark),
                     //typeof(SumBenchmark),
                     //typeof(LengthBenchmark),
-                    typeof(PointInPolygonBenchmark),
+                    //typeof(PointInPolygonBenchmark),
                     //typeof(SwapXYBenchmark),
                     //typeof(AdditionBenchmark),
                     //typeof(SmallestRotatedRectangleBenchmark),
@@ -39,12 +39,17 @@ namespace Pmad.Geometry.Benchmark
                     //typeof(CircleFromTwoPointsBenchmark),
                     //typeof(CircleFromThreePointsBenchmark),
                     //typeof(NearestPointPathBenchmark),
-                    //typeof(AngleBenchmark)
-                    //typeof(LerpBenchmark)
-                    //typeof(SimplifyBenchmark)
-                    //typeof(ComparativeBenchmark)
-                    //typeof(DotDBenchmark)
-                    //typeof(CentroidBenchmark)
+                    //typeof(AngleBenchmark),
+                    //typeof(LerpBenchmark),
+                    //typeof(SimplifyBenchmark),
+                    //typeof(ComparativeBenchmark),
+                    //typeof(DotDBenchmark),
+                    //typeof(CentroidBenchmark),
+                    //typeof(IntersectsBenchmark),
+                    //typeof(IntersectionAreaBenchmark),
+                    //typeof(IntersectionBenchmark),
+                    //typeof(UnionBenchmark),
+                    typeof(ShapeSettingsBenchmark)
                 ]);
         }
     }

--- a/tests/Pmad.Geometry.Benchmark/ShapeOperations/GetSignedAreaBenchmark.cs
+++ b/tests/Pmad.Geometry.Benchmark/ShapeOperations/GetSignedAreaBenchmark.cs
@@ -13,10 +13,9 @@ namespace Pmad.Geometry.Benchmark.ShapeOperations
         [Benchmark] public object GetSignedArea_MapKit() => SampleValues.PosListGRM.GetSignedArea();
 
         [Benchmark] public object GetSignedArea_2D_Shoelace() => SignedArea<double, Vector2D>.GetSignedAreaD(SampleValuesRO.Circle2D);
-        [Benchmark] public object GetSignedArea_2D_Classic() => SignedArea<double,Vector2D>.GetSignedAreaClassicD(SampleValuesRO.Circle2D);
-
         [Benchmark] public object GetSignedArea_2L_Shoelace() => SignedArea<long, Vector2L>.GetSignedAreaD(SampleValuesRO.Circle2L);
-        [Benchmark] public object GetSignedArea_2L_Classic() => SignedArea<long, Vector2L>.GetSignedAreaClassicD(SampleValuesRO.Circle2L);
+        [Benchmark] public object GetSignedArea_2F_Shoelace() => SignedArea<float, Vector2F>.GetSignedAreaD(SampleValuesRO.Circle2F);
+        [Benchmark] public object GetSignedArea_2I_Shoelace() => SignedArea<int, Vector2I>.GetSignedAreaD(SampleValuesRO.Circle2I);
 
     }
 }

--- a/tests/Pmad.Geometry.Benchmark/ShapeOperations/IntersectionAreaBenchmark.cs
+++ b/tests/Pmad.Geometry.Benchmark/ShapeOperations/IntersectionAreaBenchmark.cs
@@ -1,0 +1,19 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Pmad.Geometry.Benchmark.ShapeOperations
+{
+    public class IntersectionAreaBenchmark
+    {
+        private static readonly PolygonSampleSet A = PolygonSampleSet.CreateCircle(0, 0, 100); 
+        private static readonly PolygonSampleSet B = PolygonSampleSet.CreateCircle(0, 50, 100);
+        private static readonly PolygonSampleSet C = PolygonSampleSet.CreateCircle(0, 150, 100);
+
+        [Benchmark] public object IntersectionArea_NTS() => A.PolygonNTS.Intersection(B.PolygonNTS).Area + A.PolygonNTS.Intersection(C.PolygonNTS).Area;
+        [Benchmark] public object IntersectionArea_GRM() => A.PolygonGRM.IntersectionArea(B.PolygonGRM) + A.PolygonGRM.IntersectionArea(C.PolygonGRM);
+        [Benchmark] public object IntersectionArea_2D() => A.Polygon2D.IntersectionArea(B.Polygon2D) + A.Polygon2D.IntersectionArea(C.Polygon2D);
+        [Benchmark] public object IntersectionArea_2F() => A.Polygon2F.IntersectionArea(B.Polygon2F) + A.Polygon2F.IntersectionArea(C.Polygon2F);
+        [Benchmark] public object IntersectionArea_2I() => A.Polygon2I.IntersectionArea(B.Polygon2I) + A.Polygon2I.IntersectionArea(C.Polygon2I);
+        [Benchmark] public object IntersectionArea_2L() => A.Polygon2L.IntersectionArea(B.Polygon2L) + A.Polygon2L.IntersectionArea(C.Polygon2L);
+
+    }
+}

--- a/tests/Pmad.Geometry.Benchmark/ShapeOperations/IntersectionBenchmark.cs
+++ b/tests/Pmad.Geometry.Benchmark/ShapeOperations/IntersectionBenchmark.cs
@@ -1,0 +1,19 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Pmad.Geometry.Benchmark.ShapeOperations
+{
+    public class IntersectionBenchmark
+    {
+        private static readonly PolygonSampleSet A = PolygonSampleSet.CreateCircle(0, 0, 100); 
+        private static readonly PolygonSampleSet B = PolygonSampleSet.CreateCircle(0, 50, 100);
+        private static readonly PolygonSampleSet C = PolygonSampleSet.CreateCircle(0, 150, 100);
+
+        [Benchmark] public object Intersection_NTS() => (A.PolygonNTS.Intersection(B.PolygonNTS) , A.PolygonNTS.Intersection(C.PolygonNTS));
+        [Benchmark] public object Intersection_GRM() => (A.PolygonGRM.Intersection(B.PolygonGRM) , A.PolygonGRM.Intersection(C.PolygonGRM));
+        [Benchmark] public object Intersection_2D() => (A.Polygon2D.Intersection(B.Polygon2D) , A.Polygon2D.Intersection(C.Polygon2D));
+        [Benchmark] public object Intersection_2F() => (A.Polygon2F.Intersection(B.Polygon2F) , A.Polygon2F.Intersection(C.Polygon2F));
+        [Benchmark] public object Intersection_2I() => (A.Polygon2I.Intersection(B.Polygon2I) , A.Polygon2I.Intersection(C.Polygon2I));
+        [Benchmark] public object Intersection_2L() => (A.Polygon2L.Intersection(B.Polygon2L) , A.Polygon2L.Intersection(C.Polygon2L));
+
+    }
+}

--- a/tests/Pmad.Geometry.Benchmark/ShapeOperations/IntersectsBenchmark.cs
+++ b/tests/Pmad.Geometry.Benchmark/ShapeOperations/IntersectsBenchmark.cs
@@ -1,0 +1,19 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Pmad.Geometry.Benchmark.ShapeOperations
+{
+    public class IntersectsBenchmark
+    {
+        private static readonly PolygonSampleSet A = PolygonSampleSet.CreateCircle(0, 0, 100); 
+        private static readonly PolygonSampleSet B = PolygonSampleSet.CreateCircle(0, 50, 100);
+        private static readonly PolygonSampleSet C = PolygonSampleSet.CreateCircle(0, 150, 100);
+
+        [Benchmark] public object Intersects_NTS() => A.PolygonNTS.Intersects(B.PolygonNTS) && A.PolygonNTS.Intersects(C.PolygonNTS);
+        [Benchmark] public object Intersects_GRM() => A.PolygonGRM.Intersects(B.PolygonGRM) && A.PolygonGRM.Intersects(C.PolygonGRM);
+        [Benchmark] public object Intersects_2D() => A.Polygon2D.Intersects(B.Polygon2D) && A.Polygon2D.Intersects(C.Polygon2D);
+        [Benchmark] public object Intersects_2F() => A.Polygon2F.Intersects(B.Polygon2F) && A.Polygon2F.Intersects(C.Polygon2F);
+        [Benchmark] public object Intersects_2I() => A.Polygon2I.Intersects(B.Polygon2I) && A.Polygon2I.Intersects(C.Polygon2I);
+        [Benchmark] public object Intersects_2L() => A.Polygon2L.Intersects(B.Polygon2L) && A.Polygon2L.Intersects(C.Polygon2L);
+
+    }
+}

--- a/tests/Pmad.Geometry.Benchmark/ShapeOperations/ShapeSettingsBenchmark.cs
+++ b/tests/Pmad.Geometry.Benchmark/ShapeOperations/ShapeSettingsBenchmark.cs
@@ -1,0 +1,16 @@
+﻿using BenchmarkDotNet.Attributes;
+using Pmad.Geometry.Shapes;
+
+namespace Pmad.Geometry.Benchmark.ShapeOperations
+{
+    public class ShapeSettingsBenchmark
+    {
+        private readonly ShapeSettings<long, Vector2L> shapeSettings = ShapeSettings<long, Vector2L>.Default;
+
+        [Benchmark] public object FromClipper() => shapeSettings.FromClipper(SampleValues.PosListP64);
+
+        [Benchmark] public object FromClipperToRing() => shapeSettings.FromClipperToRing(SampleValues.PosListP64);
+
+        [Benchmark] public object ToClipper() => shapeSettings.ToClipper(SampleValuesRO.PosList2L);
+    }
+}

--- a/tests/Pmad.Geometry.Benchmark/ShapeOperations/UnionBenchmark.cs
+++ b/tests/Pmad.Geometry.Benchmark/ShapeOperations/UnionBenchmark.cs
@@ -1,0 +1,19 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Pmad.Geometry.Benchmark.ShapeOperations
+{
+    public class UnionBenchmark
+    {
+        private static readonly PolygonSampleSet A = PolygonSampleSet.CreateCircle(0, 0, 100); 
+        private static readonly PolygonSampleSet B = PolygonSampleSet.CreateCircle(0, 50, 100);
+        private static readonly PolygonSampleSet C = PolygonSampleSet.CreateCircle(0, 150, 100);
+
+        [Benchmark] public object Union_NTS() => (A.PolygonNTS.Union(B.PolygonNTS), A.PolygonNTS.Union(C.PolygonNTS));
+        [Benchmark] public object Union_GRM() => (A.PolygonGRM.Merge(B.PolygonGRM), A.PolygonGRM.Merge(C.PolygonGRM));
+        [Benchmark] public object Union_2D() => (A.Polygon2D.Union(B.Polygon2D) , A.Polygon2D.Union(C.Polygon2D));
+        [Benchmark] public object Union_2F() => (A.Polygon2F.Union(B.Polygon2F), A.Polygon2F.Union(C.Polygon2F));
+        [Benchmark] public object Union_2I() => (A.Polygon2I.Union(B.Polygon2I), A.Polygon2I.Union(C.Polygon2I));
+        [Benchmark] public object Union_2L() => (A.Polygon2L.Union(B.Polygon2L) , A.Polygon2L.Union(C.Polygon2L));
+
+    }
+}

--- a/tests/Pmad.Geometry.Test/Pmad.Geometry.Test.csproj
+++ b/tests/Pmad.Geometry.Test/Pmad.Geometry.Test.csproj
@@ -40,6 +40,11 @@
 	    <DesignTime>True</DesignTime>
 	    <AutoGen>True</AutoGen>
 	  </Compile>
+	  <Compile Update="Shapes\ShapeSettingsTest.cs">
+	    <DependentUpon>ShapeSettingsTest.tt</DependentUpon>
+	    <DesignTime>True</DesignTime>
+	    <AutoGen>True</AutoGen>
+	  </Compile>
 	  <Compile Update="Shapes\RotatedRectangle.cs">
 	    <DesignTime>True</DesignTime>
 	    <AutoGen>True</AutoGen>
@@ -90,6 +95,10 @@
     </None>
     <None Update="Shapes\Path.tt">
       <LastGenOutput>Path.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="Shapes\ShapeSettingsTest.tt">
+      <LastGenOutput>ShapeSettingsTest.cs</LastGenOutput>
       <Generator>TextTemplatingFileGenerator</Generator>
     </None>
     <None Update="Shapes\RotatedRectangle.tt">

--- a/tests/Pmad.Geometry.Test/Shapes/ShapeSettingsTest.cs
+++ b/tests/Pmad.Geometry.Test/Shapes/ShapeSettingsTest.cs
@@ -1,0 +1,44 @@
+﻿
+namespace Pmad.Geometry.Test.Shapes.Settings
+{
+	public partial class ShapeSettings2ITest : ShapeSettingsTestBase<int,Vector2I>
+	{
+        protected override Vector2I Vector(int x, int y) => new ((int)x, (int)y);
+		protected override int ExpectedScale => 1;
+	}
+	public partial class ShapeSettings2FTest : ShapeSettingsTestBase<float,Vector2F>
+	{
+        protected override Vector2F Vector(int x, int y) => new ((float)x, (float)y);
+		protected override int ExpectedScale => 1000;
+	}
+	public partial class ShapeSettings2LTest : ShapeSettingsTestBase<long,Vector2L>
+	{
+        protected override Vector2L Vector(int x, int y) => new ((long)x, (long)y);
+		protected override int ExpectedScale => 1;
+	}
+	public partial class ShapeSettings2DTest : ShapeSettingsTestBase<double,Vector2D>
+	{
+        protected override Vector2D Vector(int x, int y) => new ((double)x, (double)y);
+		protected override int ExpectedScale => 1000;
+	}
+	public partial class ShapeSettings2ISTest : ShapeSettingsTestBase<int,Vector2IS>
+	{
+        protected override Vector2IS Vector(int x, int y) => new ((int)x, (int)y);
+		protected override int ExpectedScale => 1;
+	}
+	public partial class ShapeSettings2FSTest : ShapeSettingsTestBase<float,Vector2FS>
+	{
+        protected override Vector2FS Vector(int x, int y) => new ((float)x, (float)y);
+		protected override int ExpectedScale => 1000;
+	}
+	public partial class ShapeSettings2LSTest : ShapeSettingsTestBase<long,Vector2LS>
+	{
+        protected override Vector2LS Vector(int x, int y) => new ((long)x, (long)y);
+		protected override int ExpectedScale => 1;
+	}
+	public partial class ShapeSettings2DSTest : ShapeSettingsTestBase<double,Vector2DS>
+	{
+        protected override Vector2DS Vector(int x, int y) => new ((double)x, (double)y);
+		protected override int ExpectedScale => 1000;
+	}
+}

--- a/tests/Pmad.Geometry.Test/Shapes/ShapeSettingsTest.tt
+++ b/tests/Pmad.Geometry.Test/Shapes/ShapeSettingsTest.tt
@@ -1,0 +1,27 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ include file="..\..\..\src\Pmad.Geometry\Definitions.tt" #>
+<#@ output extension=".cs" #>
+
+namespace Pmad.Geometry.Test.Shapes.Settings
+{
+<#
+	foreach(var def in definitions)
+	{
+#>
+	public partial class ShapeSettings<#=def.Suffix#>Test : ShapeSettingsTestBase<<#=def.Primitive#>,<#=def.Struct#>>
+	{
+        protected override <#=def.Struct#> Vector(int x, int y) => new ((<#=def.Primitive#>)x, (<#=def.Primitive#>)y);
+<# if ( def.IsFP) { #>
+		protected override int ExpectedScale => 1000;
+<# } else { #>
+		protected override int ExpectedScale => 1;
+<# } #>
+	}
+<#
+	}
+#>
+}

--- a/tests/Pmad.Geometry.Test/Shapes/ShapeSettingsTestBase.cs
+++ b/tests/Pmad.Geometry.Test/Shapes/ShapeSettingsTestBase.cs
@@ -1,0 +1,132 @@
+﻿using System.Numerics;
+using Clipper2Lib;
+using Pmad.Geometry.Collections;
+using Pmad.Geometry.Shapes;
+
+namespace Pmad.Geometry.Test.Shapes
+{
+    public abstract class ShapeSettingsTestBase<TPrimitive, TVector>
+        where TPrimitive : unmanaged, INumber<TPrimitive>
+        where TVector : struct, IVector2<TPrimitive, TVector>
+    {
+        protected abstract TVector Vector(int x, int y);
+
+        protected abstract int ExpectedScale { get; }
+
+        [Fact]
+        public void Default()
+        {
+            var settings = ShapeSettings<TPrimitive, TVector>.Default;
+            Assert.Equal(ExpectedScale, settings.ScaleForClipper);
+            Assert.Equal(9, settings.NegligibleClipperArea);
+            Assert.Equal(9, settings.NegligibleArea * ExpectedScale * ExpectedScale, 0.00001);
+            Assert.Equal(3, settings.NegligibleDistance * ExpectedScale, 0.00001);
+        }
+
+        [Fact]
+        public void FromClipperToRing()
+        {
+            var points = new Path64()
+            {
+                new Point64( 10 * ExpectedScale, 20 * ExpectedScale ),
+                new Point64( 30 * ExpectedScale, 40 * ExpectedScale ),
+                new Point64( 50 * ExpectedScale, 60 * ExpectedScale ),
+                new Point64( 70 * ExpectedScale, 80 * ExpectedScale ),
+            };
+
+            var settings = ShapeSettings<TPrimitive, TVector>.Default;
+
+            Assert.Equal([
+                Vector(10,20),
+                Vector(30,40),
+                Vector(50,60),
+                Vector(70,80),
+                Vector(10,20)], settings.FromClipperToRing(points));
+        }
+
+        [Fact]
+        public void FromClipper_Vector()
+        {
+            var settings = ShapeSettings<TPrimitive, TVector>.Default;
+            Assert.Equal(Vector(10, 20), settings.FromClipper(new Point64(10 * ExpectedScale, 20 * ExpectedScale)));
+            Assert.Equal(Vector(30, 40), settings.FromClipper(new Point64(30 * ExpectedScale, 40 * ExpectedScale)));
+        }
+
+        [Fact]
+        public void FromClipper_Array()
+        {
+            var points = new Path64()
+            {
+                new Point64( 10 * ExpectedScale, 20 * ExpectedScale ),
+                new Point64( 30 * ExpectedScale, 40 * ExpectedScale ),
+                new Point64( 50 * ExpectedScale, 60 * ExpectedScale ),
+                new Point64( 70 * ExpectedScale, 80 * ExpectedScale ),
+            };
+
+            var settings = ShapeSettings<TPrimitive, TVector>.Default;
+
+            Assert.Equal([
+                Vector(10,20),
+                Vector(30,40),
+                Vector(50,60),
+                Vector(70,80)], settings.FromClipper(points));
+        }
+
+        [Fact]
+        public void ToClipper_Array()
+        {
+            var points = new ReadOnlyArray<TVector>(
+                Vector(10, 20),
+                Vector(30, 40),
+                Vector(50, 60),
+                Vector(70, 80));
+
+            var settings = ShapeSettings<TPrimitive, TVector>.Default;
+
+            Assert.Equal([
+                new Point64( 10 * ExpectedScale, 20 * ExpectedScale ),
+                new Point64( 30 * ExpectedScale, 40 * ExpectedScale ),
+                new Point64( 50 * ExpectedScale, 60 * ExpectedScale ),
+                new Point64( 70 * ExpectedScale, 80 * ExpectedScale )], settings.ToClipper(points));
+        }
+
+        [Fact]
+        public void ToClipper_Vector()
+        {
+            var settings = ShapeSettings<TPrimitive, TVector>.Default;
+
+            Assert.Equal(new Point64(10 * ExpectedScale, 20 * ExpectedScale), settings.ToClipper(Vector(10, 20)));
+            Assert.Equal(new Point64(30 * ExpectedScale, 40 * ExpectedScale), settings.ToClipper(Vector(30, 40)));
+        }
+
+        [Fact]
+        public void ToClipper_Envelope()
+        {
+            var settings = ShapeSettings<TPrimitive, TVector>.Default;
+
+            var rect = settings.ToClipper(new VectorEnvelope<TVector>(Vector(10,20), Vector(30,50)));
+            Assert.Equal(20 * ExpectedScale, rect.Width);
+            Assert.Equal(30 * ExpectedScale, rect.Height);
+            Assert.Equal(10 * ExpectedScale, rect.left);
+            Assert.Equal(20 * ExpectedScale, rect.top);
+            Assert.Equal(30 * ExpectedScale, rect.right);
+            Assert.Equal(50 * ExpectedScale, rect.bottom);
+        }
+
+        [Fact]
+        public void AlmostEquals()
+        {
+            var settings = ShapeSettings<TPrimitive, TVector>.Default;
+
+            // Distance less than 3
+            Assert.True(settings.AlmostEquals(settings.FromClipper(new Point64(5, 5)), settings.FromClipper(new Point64(5, 5))));
+            Assert.True(settings.AlmostEquals(settings.FromClipper(new Point64(5, 7)), settings.FromClipper(new Point64(5, 5))));
+            Assert.True(settings.AlmostEquals(settings.FromClipper(new Point64(7, 5)), settings.FromClipper(new Point64(5, 5))));
+
+            // Distance 3 or above
+            Assert.False(settings.AlmostEquals(settings.FromClipper(new Point64(8, 8)), settings.FromClipper(new Point64(5, 5))));
+            Assert.False(settings.AlmostEquals(settings.FromClipper(new Point64(5, 8)), settings.FromClipper(new Point64(5, 5))));
+            Assert.False(settings.AlmostEquals(settings.FromClipper(new Point64(8, 5)), settings.FromClipper(new Point64(5, 5))));
+        }
+    }
+}


### PR DESCRIPTION
- Improve FromClipper/FromClipperToRing performance : slightly faster, by using Span
- Improve ToClipper performance : 7 times faster, by replacing Linq call with explicit implementation
- Unit tests on ShapeSettings
- Add some benchmarks on Polygon